### PR TITLE
Make MaterialProperty references const

### DIFF
--- a/include/auxkernels/AdvectiveFlux.h
+++ b/include/auxkernels/AdvectiveFlux.h
@@ -37,9 +37,9 @@ class AdvectiveFlux : public AuxKernel
   
   // Material properties
 
-  MaterialProperty<Real> & _mobility;
-  MaterialProperty<Real> & _electron_mult;
-  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _mobility;
+  const MaterialProperty<Real> & _electron_mult;
+  const MaterialProperty<Real> & _potential_mult;
   
   // Coupled variables
 

--- a/include/auxkernels/AlphaTimesHSize.h
+++ b/include/auxkernels/AlphaTimesHSize.h
@@ -25,7 +25,7 @@ protected:
 
   // Material Properties
   
-  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _potential_mult;
 
   // Coupled variables
   

--- a/include/auxkernels/ChargeDensity.h
+++ b/include/auxkernels/ChargeDensity.h
@@ -22,7 +22,7 @@ protected:
   VariableValue & _electron_density;
   VariableValue & _ion_density;
 
-  MaterialProperty<Real> & _coulomb_charge;
+  const MaterialProperty<Real> & _coulomb_charge;
 };
 
 #endif //CHARGEDENSITY_H

--- a/include/auxkernels/DiffusiveFlux.h
+++ b/include/auxkernels/DiffusiveFlux.h
@@ -23,8 +23,8 @@ class DiffusiveFlux : public AuxKernel
   
   // Material properties
 
-  MaterialProperty<Real> & _diffusivity;
-  MaterialProperty<Real> & _electron_mult;
+  const MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _electron_mult;
   
   // Coupled variables
 

--- a/include/auxkernels/IonSrcTerm.h
+++ b/include/auxkernels/IonSrcTerm.h
@@ -25,8 +25,8 @@ protected:
 
   // Material Properties
   
-  MaterialProperty<Real> & _potential_mult;
-  MaterialProperty<Real> & _velocity_coeff;
+  const MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _velocity_coeff;
 
   // Coupled variables
   

--- a/include/auxkernels/Sigma.h
+++ b/include/auxkernels/Sigma.h
@@ -50,9 +50,9 @@ protected:
   
   // Material properties
 
-  MaterialProperty<Real> & _tau; 
-  MaterialProperty<RealVectorValue> & _velocity; 
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _tau; 
+  const MaterialProperty<RealVectorValue> & _velocity; 
+  const MaterialProperty<Real> & _diffusivity;
 
   // Kernel specific members
 

--- a/include/auxkernels/Velocity.h
+++ b/include/auxkernels/Velocity.h
@@ -50,9 +50,9 @@ protected:
   
   // Material properties
 
-  MaterialProperty<Real> & _tau; 
-  MaterialProperty<RealVectorValue> & _velocity; 
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _tau; 
+  const MaterialProperty<RealVectorValue> & _velocity; 
+  const MaterialProperty<Real> & _diffusivity;
 
   // Kernel specific members
 

--- a/include/auxkernels/VelocityH.h
+++ b/include/auxkernels/VelocityH.h
@@ -50,9 +50,9 @@ protected:
   
   // Material properties
 
-  MaterialProperty<Real> & _tau; 
-  MaterialProperty<RealVectorValue> & _velocity; 
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _tau; 
+  const MaterialProperty<RealVectorValue> & _velocity; 
+  const MaterialProperty<Real> & _diffusivity;
 
   // Kernel specific members
 

--- a/include/auxkernels/VelocityMag.h
+++ b/include/auxkernels/VelocityMag.h
@@ -46,8 +46,8 @@ protected:
   /// The gradient of a coupled variable
   //  VariableGradient & _grad_potential;
   
-  //  MaterialProperty<Real> & _velocity_coeff;
-  MaterialProperty<RealVectorValue> & _velocity;
+  //  const MaterialProperty<Real> & _velocity_coeff;
+  const MaterialProperty<RealVectorValue> & _velocity;
 };
 
 #endif //VELOCITYMAG_H

--- a/include/bcs/EFieldBC.h
+++ b/include/bcs/EFieldBC.h
@@ -48,8 +48,8 @@ protected:
 
   // Material Properties
 
-  MaterialProperty<Real> & _eps_r;
-  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _eps_r;
+  const MaterialProperty<Real> & _potential_mult;
 
   // Members unique to object
 

--- a/include/bcs/NoDiffusiveFlux.h
+++ b/include/bcs/NoDiffusiveFlux.h
@@ -42,7 +42,7 @@ protected:
 
   // Material Properties
 
-  MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<RealVectorValue> & _velocity;
 };
 
 

--- a/include/bcs/PhysicalElectronBC.h
+++ b/include/bcs/PhysicalElectronBC.h
@@ -31,12 +31,12 @@ protected:
   
   // Material Properties
 
-  MaterialProperty<RealVectorValue> & _advection_velocity_em;
-  MaterialProperty<Real> & _muem;
-  MaterialProperty<Real> & _v_thermal_em;
-  MaterialProperty<RealVectorValue> & _gamma_ip;
-  MaterialProperty<RealVectorValue> & _advection_velocity_ip;
-  MaterialProperty<Real> & _muip;
+  const MaterialProperty<RealVectorValue> & _advection_velocity_em;
+  const MaterialProperty<Real> & _muem;
+  const MaterialProperty<Real> & _v_thermal_em;
+  const MaterialProperty<RealVectorValue> & _gamma_ip;
+  const MaterialProperty<RealVectorValue> & _advection_velocity_ip;
+  const MaterialProperty<Real> & _muip;
 
   // Coupled variables
   

--- a/include/bcs/PhysicalIonBC.h
+++ b/include/bcs/PhysicalIonBC.h
@@ -28,9 +28,9 @@ protected:
   
   // Material Properties
 
-  MaterialProperty<RealVectorValue> & _advection_velocity_ip;
-  MaterialProperty<Real> & _muip;
-  MaterialProperty<Real> & _v_thermal_ip;
+  const MaterialProperty<RealVectorValue> & _advection_velocity_ip;
+  const MaterialProperty<Real> & _muip;
+  const MaterialProperty<Real> & _v_thermal_ip;
 };
 
 #endif //PHYSICALIONBC_H

--- a/include/bcs/SpeciesNetFluxBC.h
+++ b/include/bcs/SpeciesNetFluxBC.h
@@ -26,10 +26,10 @@ protected:
 
   // Material Properties
 
-  MaterialProperty<Real> & _species_charge;
-  MaterialProperty<Real> & _coulomb_charge;
-  MaterialProperty<Real> & _electron_mult;
-  MaterialProperty<Real> & _N_A;
+  const MaterialProperty<Real> & _species_charge;
+  const MaterialProperty<Real> & _coulomb_charge;
+  const MaterialProperty<Real> & _electron_mult;
+  const MaterialProperty<Real> & _N_A;
 
   // Members unique to object
 

--- a/include/kernels/ArtificialDiff.h
+++ b/include/kernels/ArtificialDiff.h
@@ -43,9 +43,9 @@ protected:
   
   // Material Properties
   
-  MaterialProperty<RealVectorValue> & _velocity;
-  MaterialProperty<Real> & _tau;
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<Real> & _tau;
+  const MaterialProperty<Real> & _diffusivity;
   
   // Coupled variables
 

--- a/include/kernels/CoeffDiffusion.h
+++ b/include/kernels/CoeffDiffusion.h
@@ -38,7 +38,7 @@ protected:
 
   //  const std::string _string;
 
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _diffusivity;
 };
 
 

--- a/include/kernels/ConstConvectionSUPG.h
+++ b/include/kernels/ConstConvectionSUPG.h
@@ -43,9 +43,9 @@ protected:
 
   // Unique to kernel
   
-  MaterialProperty<RealVectorValue> & _velocity;
-  MaterialProperty<Real> & _alpha;
-  MaterialProperty<RealVectorValue> & _velocity_norm;
+  const MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<Real> & _alpha;
+  const MaterialProperty<RealVectorValue> & _velocity_norm;
 };
 
 #endif //CONSTCONVECTIONSUPG_H

--- a/include/kernels/CoupledBEKinetic.h
+++ b/include/kernels/CoupledBEKinetic.h
@@ -51,7 +51,7 @@ protected:
 
 private:
   /// Material property of porosity.
-  MaterialProperty<Real> & _porosity;
+  const MaterialProperty<Real> & _porosity;
 
   /// Weight of the kinetic mineral concentration in the total primary species concentration.
   std::vector<Real> _weight;

--- a/include/kernels/CoupledIonizationSource.h
+++ b/include/kernels/CoupledIonizationSource.h
@@ -35,12 +35,12 @@ protected:
   
   // Material properties
   
-  MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<RealVectorValue> & _velocity;
 
-  /*  MaterialProperty<Real> & _ionization_coeff;
-  MaterialProperty<Real> & _ion_activation_energy;
-  MaterialProperty<Real> & _potential_mult;
-  MaterialProperty<Real> & _velocity_coeff; */
+  /*  const MaterialProperty<Real> & _ionization_coeff;
+  const MaterialProperty<Real> & _ion_activation_energy;
+  const MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _velocity_coeff; */
   
   // Coupled variables
   

--- a/include/kernels/DivFreeConvection.h
+++ b/include/kernels/DivFreeConvection.h
@@ -39,10 +39,10 @@ protected:
   
   // Material Properties
   
-  /*  MaterialProperty<Real> & _velocity_coeff;
-      MaterialProperty<Real> & _potential_mult; */
+  /*  const MaterialProperty<Real> & _velocity_coeff;
+      const MaterialProperty<Real> & _potential_mult; */
 
-  MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<RealVectorValue> & _velocity;
   
   // Coupled variables
   

--- a/include/kernels/EFieldAdvection.h
+++ b/include/kernels/EFieldAdvection.h
@@ -41,8 +41,8 @@ class EFieldAdvection : public Kernel
   
   // Material properties
 
-  MaterialProperty<Real> & _mobility;
-  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _mobility;
+  const MaterialProperty<Real> & _potential_mult;
   // Coupled variables
   
   unsigned int _potential_id;

--- a/include/kernels/ExampleDiffusion.h
+++ b/include/kernels/ExampleDiffusion.h
@@ -42,6 +42,6 @@ protected:
    * This MooseArray will hold the reference we need to our
    * material property from the Material class
    */
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _diffusivity;
 };
 #endif //EXAMPLEDIFFUSION_H

--- a/include/kernels/IonizationSource.h
+++ b/include/kernels/IonizationSource.h
@@ -35,12 +35,12 @@ protected:
   
   // Material properties
   
-  MaterialProperty<RealVectorValue> & _velocity;
+  const MaterialProperty<RealVectorValue> & _velocity;
 
-  /*  MaterialProperty<Real> & _ionization_coeff;
-  MaterialProperty<Real> & _velocity_coeff;
-  MaterialProperty<Real> & _ion_activation_energy;
-  MaterialProperty<Real> & _potential_mult; */
+  /*  const MaterialProperty<Real> & _ionization_coeff;
+  const MaterialProperty<Real> & _velocity_coeff;
+  const MaterialProperty<Real> & _ion_activation_energy;
+  const MaterialProperty<Real> & _potential_mult; */
   
   // Coupled variables
   

--- a/include/kernels/MatAdvection.h
+++ b/include/kernels/MatAdvection.h
@@ -41,9 +41,9 @@ protected:
   
   // Material properties
   
-  MaterialProperty<RealVectorValue> & _velocity;
-  //  MaterialProperty<Real> & _velocity_coeff;
-  //  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<RealVectorValue> & _velocity;
+  //  const MaterialProperty<Real> & _velocity_coeff;
+  //  const MaterialProperty<Real> & _potential_mult;
   
   // Coupled variables
   

--- a/include/kernels/NSKernel.h
+++ b/include/kernels/NSKernel.h
@@ -68,8 +68,8 @@ protected:
   Real _R;
 
   // Integrated BC can use Mat. properties...
-  MaterialProperty<Real> & _dynamic_viscosity;
-  MaterialProperty<RealTensorValue> & _viscous_stress_tensor; // Includes _dynamic_viscosity
+  const MaterialProperty<Real> & _dynamic_viscosity;
+  const MaterialProperty<RealTensorValue> & _viscous_stress_tensor; // Includes _dynamic_viscosity
 
   // Helper function for mapping Moose variable numberings into
   // the "canonical" numbering for the compressible NS equations.

--- a/include/kernels/PoissonSource.h
+++ b/include/kernels/PoissonSource.h
@@ -35,10 +35,10 @@ protected:
   
   // Material properties
   
-  MaterialProperty<Real> & _permittivity;
-  MaterialProperty<Real> & _coulomb_charge;
-  MaterialProperty<Real> & _density_mult;
-  MaterialProperty<Real> & _potential_mult;
+  const MaterialProperty<Real> & _permittivity;
+  const MaterialProperty<Real> & _coulomb_charge;
+  const MaterialProperty<Real> & _density_mult;
+  const MaterialProperty<Real> & _potential_mult;
   
   // Coupled variables
   

--- a/include/kernels/PotentialDrivenArtificialDiff.h
+++ b/include/kernels/PotentialDrivenArtificialDiff.h
@@ -47,8 +47,8 @@ protected:
   
   // Material Properties
   
-  MaterialProperty<Real> & _mobility;
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _mobility;
+  const MaterialProperty<Real> & _diffusivity;
 
   // Variables unique to the kernel
 

--- a/include/kernels/Source.h
+++ b/include/kernels/Source.h
@@ -21,8 +21,8 @@ class Source : public Kernel
 
   // Material properties
 
-  MaterialProperty<Real> & _source;
-  MaterialProperty<Real> & _jacobian;
+  const MaterialProperty<Real> & _source;
+  const MaterialProperty<Real> & _jacobian;
 };
 
 #endif /* SOURCE_H */

--- a/include/kernels/TimeDerivativeSUPG.h
+++ b/include/kernels/TimeDerivativeSUPG.h
@@ -40,10 +40,10 @@ protected:
 
   // Material properties
 
-  MaterialProperty<Real> & _tau;
-  //  MaterialProperty<RealVectorValue> & _velocity;  
-  MaterialProperty<RealVectorValue> & _velocity; 
-  MaterialProperty<Real> & _diffusivity;
+  const MaterialProperty<Real> & _tau;
+  //  const MaterialProperty<RealVectorValue> & _velocity;  
+  const MaterialProperty<RealVectorValue> & _velocity; 
+  const MaterialProperty<Real> & _diffusivity;
 
   // Kernel specific members
 


### PR DESCRIPTION
Prepare for upcoming MOOSE change: https://github.com/idaholab/moose/pull/5224
This works with the current MOOSE. 