### PR TITLE
libMesh::TypeVector::size() and size_sq() have been deprecated.

### DIFF
--- a/src/auxkernels/AlphaTimesHSize.C
+++ b/src/auxkernels/AlphaTimesHSize.C
@@ -26,5 +26,5 @@ AlphaTimesHSize::AlphaTimesHSize(const InputParameters & parameters) :
 Real
 AlphaTimesHSize::computeValue()
 {
-  return fmax(1.0e5 * std::exp(1.0 - 1.0e7/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0)) - 9697.2,0.0)*_current_elem->hmax();
+  return fmax(1.0e5 * std::exp(1.0 - 1.0e7/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0)) - 9697.2,0.0)*_current_elem->hmax();
 }

--- a/src/auxkernels/AuxSource.C
+++ b/src/auxkernels/AuxSource.C
@@ -25,8 +25,8 @@ AuxSource::AuxSource(const InputParameters & parameters) :
 Real
 AuxSource::computeValue()
 {
-  return 0.35*std::exp(-1.65e7/(_grad_potential[_qp].size()))*(-_muem*-_grad_potential[_qp]*_em[_qp]-_diff*_grad_em[_qp]).size();
-  // return 1.0/(_grad_potential.size());
+  return 0.35 * std::exp(-1.65e7/(_grad_potential[_qp].norm())) * (-_muem*-_grad_potential[_qp]*_em[_qp]-_diff*_grad_em[_qp]).norm();
+  // return 1.0/(_grad_potential.norm());
 }
 
  

--- a/src/auxkernels/Current.C
+++ b/src/auxkernels/Current.C
@@ -35,7 +35,7 @@ Current::computeValue()
 
   if (_art_diff)
   {
-    Real vd_mag = _mu[_qp] * _grad_potential[_qp].size() * _r_units;
+    Real vd_mag = _mu[_qp] * _grad_potential[_qp].norm() * _r_units;
     Real delta = vd_mag * _current_elem->hmax()/2.;
     r += _sgn[_qp] * 1.6e-19 * 6.02e23 * -delta * std::exp(_density_log[_qp]) * _grad_density_log[_qp](0) * _r_units;
   }

--- a/src/auxkernels/EFieldMag.C
+++ b/src/auxkernels/EFieldMag.C
@@ -46,6 +46,6 @@ EFieldMag::computeValue()
   // Then pull out the "component" of it we are looking for (x, y or z)
   // Note that getting a particular component of a gradient is done using the
   // parenthesis operator
-  return _grad_potential[_qp].size();
+  return _grad_potential[_qp].norm();
   // return _grad_potential[_qp](_component);
 }

--- a/src/auxkernels/ElectronArtDiffusiveFlux.C
+++ b/src/auxkernels/ElectronArtDiffusiveFlux.C
@@ -29,7 +29,7 @@ ElectronArtDiffusiveFlux::ElectronArtDiffusiveFlux(const InputParameters & param
 Real
 ElectronArtDiffusiveFlux::computeValue()
 {
-  _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   _alpha = std::min(1.0,_Pe/6.0);
   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/auxkernels/IonSrcTerm.C
+++ b/src/auxkernels/IonSrcTerm.C
@@ -29,5 +29,5 @@ IonSrcTerm::IonSrcTerm(const InputParameters & parameters) :
 Real
 IonSrcTerm::computeValue()
 {
-  return std::exp(-1.0/(_grad_potential[_qp].size()+1.0e-6))*_grad_potential[_qp].size()*_electron_density[_qp];
+  return std::exp(-1.0/(_grad_potential[_qp].norm()+1.0e-6))*_grad_potential[_qp].norm()*_electron_density[_qp];
 }

--- a/src/auxkernels/PowerDep.C
+++ b/src/auxkernels/PowerDep.C
@@ -41,7 +41,7 @@ PowerDep::computeValue()
 
   if (_art_diff)
   {
-    Real vd_mag = _mu[_qp] * _grad_potential[_qp].size() * _r_units;
+    Real vd_mag = _mu[_qp] * _grad_potential[_qp].norm() * _r_units;
     Real delta = vd_mag * _current_elem->hmax()/2.;
     _current += _sgn[_qp] * 1.6e-19 * 6.02e23 * -delta * std::exp(_density_log[_qp]) * _grad_density_log[_qp] * _r_units;
   }

--- a/src/auxkernels/ProcRate.C
+++ b/src/auxkernels/ProcRate.C
@@ -32,5 +32,5 @@ ProcRate::computeValue()
 {
   _em_current = 6.02e23 * (_sgnem[_qp] * _muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) - _diffem[_qp]* std::exp(_em[_qp]) * _grad_em[_qp] * _r_units);
 
-  return _alpha[_qp] * _em_current.size();
+  return _alpha[_qp] * _em_current.norm();
 }

--- a/src/auxkernels/Sigma.C
+++ b/src/auxkernels/Sigma.C
@@ -59,21 +59,21 @@ Sigma::Sigma(const InputParameters & parameters) :
 Real
 Sigma::computeValue()
 {
-  if (_grad_some_var[_qp].size() == 0)
+  if (_grad_some_var[_qp].norm() == 0)
     {
       _velocity_h = _velocity[_qp];
-      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]);
       return _sigma;
     }
   else
     {
-      _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].size(),2) * _grad_some_var[_qp];
-      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].norm(),2) * _grad_some_var[_qp];
+      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]);
       return _sigma;
     }

--- a/src/auxkernels/Velocity.C
+++ b/src/auxkernels/Velocity.C
@@ -59,22 +59,22 @@ Velocity::Velocity(const InputParameters & parameters) :
 Real
 Velocity::computeValue()
 {
-  if (_grad_some_var[_qp].size() == 0)
+  if (_grad_some_var[_qp].norm() == 0)
     {
       /* _velocity_h = _velocity[_qp];
-      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]); */
-      return _velocity[_qp].size();
+      return _velocity[_qp].norm();
     }
   else
     {
-      /* _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].size(),2) * _grad_some_var[_qp];
-      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      /* _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].norm(),2) * _grad_some_var[_qp];
+      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]); */
-      return _velocity[_qp].size();
+      return _velocity[_qp].norm();
     }
 }

--- a/src/auxkernels/VelocityH.C
+++ b/src/auxkernels/VelocityH.C
@@ -59,22 +59,22 @@ VelocityH::VelocityH(const InputParameters & parameters) :
 Real
 VelocityH::computeValue()
 {
-  if (_grad_some_var[_qp].size() == 0)
+  if (_grad_some_var[_qp].norm() == 0)
     {
       _velocity_h = _velocity[_qp];
-      /*      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      /*      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]); */
-      return _velocity_h.size();
+      return _velocity_h.norm();
     }
   else
     {
-      _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].size(),2) * _grad_some_var[_qp];
-      /*      _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+      _velocity_h = _velocity[_qp]*_grad_some_var[_qp] / std::pow(_grad_some_var[_qp].norm(),2) * _grad_some_var[_qp];
+      /*      _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
       _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+      _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
       _sigma = std::max(0.0,_tau_h-_tau[_qp]); */
-      return _velocity_h.size();
+      return _velocity_h.norm();
     }
 }

--- a/src/auxkernels/VelocityMag.C
+++ b/src/auxkernels/VelocityMag.C
@@ -51,6 +51,6 @@ VelocityMag::computeValue()
   // Then pull out the "component" of it we are looking for (x, y or z)
   // Note that getting a particular component of a gradient is done using the
   // parenthesis operator
-  return _velocity[_qp].size();
+  return _velocity[_qp].norm();
   // return _grad_potential[_qp](_component);
 }

--- a/src/kernels/AdvectionDiffusionKernel.C
+++ b/src/kernels/AdvectionDiffusionKernel.C
@@ -26,7 +26,7 @@ AdvectionDiffusionKernel::~AdvectionDiffusionKernel()
 Real
 AdvectionDiffusionKernel::computeQpResidual()
 {
-  _vd_mag = _a.size();
+  _vd_mag = _a.norm();
   _Pe = _vd_mag*_current_elem->hmax()/_diff;
   _alpha = std::min(1.0,_Pe/6.0);
   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -37,7 +37,7 @@ AdvectionDiffusionKernel::computeQpResidual()
 Real
 AdvectionDiffusionKernel::computeQpJacobian()
 {
-  _vd_mag = _a.size();
+  _vd_mag = _a.norm();
   _Pe = _vd_mag*_current_elem->hmax()/_diff;
   _alpha = std::min(1.0,_Pe/6.0);
   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/ArpKernel.C
+++ b/src/kernels/ArpKernel.C
@@ -47,20 +47,20 @@ ArpKernel::~ArpKernel()
 Real
 ArpKernel::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
  
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(_muip[_qp]*-_grad_potential[_qp]-_diffip[_qp]*_grad_u[_qp])
-    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm(); // Reaction. Townsend coefficient formulation
     // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 Real
 ArpKernel::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -77,14 +77,14 @@ ArpKernel::computeQpOffDiagJacobian(unsigned int jvar)
     _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
 
     return -_grad_test[_i][_qp]*(_muip[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]))
-      -_test[_i][_qp]*_rate_coeff_ion[_qp]*(std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].size()))*_Eiz[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(std::numeric_limits<double>::epsilon()+std::pow(_grad_potential[_qp].size(),3))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size() + std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].size()))*_em_flux*_d_em_flux_d_potential/(_em_flux.size()+std::numeric_limits<double>::epsilon())); // Reaction. Townsend coefficient formulation
+      -_test[_i][_qp]*_rate_coeff_ion[_qp]*(std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].norm()))*_Eiz[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(std::numeric_limits<double>::epsilon()+std::pow(_grad_potential[_qp].norm(),3))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm() + std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].norm()))*_em_flux*_d_em_flux_d_potential/(_em_flux.norm()+std::numeric_limits<double>::epsilon())); // Reaction. Townsend coefficient formulation
   }
 
   else if (jvar == _em_id) {
     _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
     _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_em[_qp])*_grad_phi[_j][_qp]+std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]);
 
-    return -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].size()))*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon()); // Reaction. Townsend coefficient formulation
+    return -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(std::numeric_limits<double>::epsilon()+_grad_potential[_qp].norm()))*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon()); // Reaction. Townsend coefficient formulation
 
   }
 

--- a/src/kernels/ArtificialDiff.C
+++ b/src/kernels/ArtificialDiff.C
@@ -70,25 +70,25 @@ Real
 ArtificialDiff::computeQpResidual()
 {
   // Use the MaterialProperty references we stored earlier
-  // return _delta*_current_elem->hmax()*_grad_potential[_qp].size()* Diffusion::computeQpResidual();
+  // return _delta*_current_elem->hmax()*_grad_potential[_qp].norm()* Diffusion::computeQpResidual();
   if (_crosswind)
     {
-      if (_grad_u[_qp].size() == 0.0)
+      if (_grad_u[_qp].norm() == 0.0)
 	{
 	  _velocity_h = _velocity[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma*_velocity_h* _grad_test[_i][_qp]) * _velocity[_qp] * _grad_u[_qp];
 	}
       else
 	{
-	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].size() * _grad_u[_qp].size() + _epsilon ) * _grad_u[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].norm() * _grad_u[_qp].norm() + _epsilon ) * _grad_u[_qp];
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma * _velocity_h * _grad_test[_i][_qp] ) * _velocity[_qp] * _grad_u[_qp];
@@ -104,26 +104,26 @@ Real
 ArtificialDiff::computeQpJacobian()
 {
   // Use the MaterialProperty references we stored earlier
-  // return _delta*_current_elem->hmax()*_grad_potential[_qp].size()*Diffusion::computeQpJacobian();
+  // return _delta*_current_elem->hmax()*_grad_potential[_qp].norm()*Diffusion::computeQpJacobian();
   if (_crosswind)
     {
-      if (_grad_u[_qp].size() == 0.0)
+      if (_grad_u[_qp].norm() == 0.0)
 	{
 	  _velocity_h = _velocity[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
  	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma*_velocity_h* _grad_test[_i][_qp]) * _velocity[_qp] * _grad_phi[_j][_qp];
 	}
       else
 	{
-	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].size() * _grad_u[_qp].size() + _epsilon ) * _grad_u[_qp];
-	  _d_velocity_h_d_uj =  (std::pow(_grad_u[_qp].size(),2)* ( _velocity[_qp] * _grad_phi[_j][_qp])-(_velocity[_qp] * _grad_u[_qp] )* ( 2.0 * _grad_u[_qp] * _grad_phi[_j][_qp] ) ) / std::pow(_grad_u[_qp].size(),4)*_grad_u[_qp] + _velocity[_qp]*_grad_u[_qp] / std::pow(_grad_u[_qp].size(),2) * _grad_phi[_j][_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].norm() * _grad_u[_qp].norm() + _epsilon ) * _grad_u[_qp];
+	  _d_velocity_h_d_uj =  (std::pow(_grad_u[_qp].norm(),2)* ( _velocity[_qp] * _grad_phi[_j][_qp])-(_velocity[_qp] * _grad_u[_qp] )* ( 2.0 * _grad_u[_qp] * _grad_phi[_j][_qp] ) ) / std::pow(_grad_u[_qp].norm(),4)*_grad_u[_qp] + _velocity[_qp]*_grad_u[_qp] / std::pow(_grad_u[_qp].norm(),2) * _grad_phi[_j][_qp];
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 

--- a/src/kernels/CoupledIonizationSource.C
+++ b/src/kernels/CoupledIonizationSource.C
@@ -49,9 +49,9 @@ This scaling is evident anywhere where you see the potential multiplied by 1.0e4
 Real
 CoupledIonizationSource::computeQpResidual()
 {
-  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].size()*_electron_density[_qp]; */
+  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].norm()*_electron_density[_qp]; */
 
-  return -_test[_i][_qp]*std::max(std::exp(-1.0/(_grad_potential[_qp].size()+1.0e-6))*_velocity[_qp].size()*_electron_density[_qp],0.0);
+  return -_test[_i][_qp]*std::max(std::exp(-1.0/(_grad_potential[_qp].norm()+1.0e-6))*_velocity[_qp].norm()*_electron_density[_qp],0.0);
 
 }
 
@@ -66,12 +66,12 @@ CoupledIonizationSource::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id)
   {
-    return _test[_i][_qp]*_ionization_coeff[_qp]*_velocity_coeff[_qp]*_electron_density[_qp]*_potential_mult[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*(_ion_activation_energy[_qp]/(_grad_potential[_qp]*_grad_potential[_qp]*std::pow(_potential_mult[_qp],2)+1.0)-1.0/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0));
+    return _test[_i][_qp]*_ionization_coeff[_qp]*_velocity_coeff[_qp]*_electron_density[_qp]*_potential_mult[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*(_ion_activation_energy[_qp]/(_grad_potential[_qp]*_grad_potential[_qp]*std::pow(_potential_mult[_qp],2)+1.0)-1.0/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0));
   }
 
   if (jvar == _electrons_id)
   {
-    return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].size()*_phi[_j][_qp];
+    return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].norm()*_phi[_j][_qp];
   }
   
   return 0.0;

--- a/src/kernels/EFieldArtDiff.C
+++ b/src/kernels/EFieldArtDiff.C
@@ -31,7 +31,7 @@ EFieldArtDiff::~EFieldArtDiff()
 Real
 EFieldArtDiff::computeQpResidual()
 {
-  Real  vd_mag = _mu[_qp]*_grad_potential[_qp].size();
+  Real  vd_mag = _mu[_qp]*_grad_potential[_qp].norm();
   Real  delta = vd_mag*_current_elem->hmax()/2.0;
 
   return -_grad_test[_i][_qp]*(-delta*std::exp(_u[_qp])*_grad_u[_qp]) * _scale;
@@ -40,7 +40,7 @@ EFieldArtDiff::computeQpResidual()
 Real
 EFieldArtDiff::computeQpJacobian()
 {
-  Real  vd_mag = _mu[_qp]*_grad_potential[_qp].size();
+  Real  vd_mag = _mu[_qp]*_grad_potential[_qp].norm();
   Real  delta = vd_mag*_current_elem->hmax()/2.0;
 
   return -_grad_test[_i][_qp]*(-delta*(std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp] + std::exp(_u[_qp])*_grad_phi[_j][_qp])) * _scale;
@@ -50,8 +50,8 @@ Real
 EFieldArtDiff::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) {
-    Real  vd_mag = _mu[_qp]*_grad_potential[_qp].size();
-    Real  d_vd_mag_d_potential = _mu[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+    Real  vd_mag = _mu[_qp]*_grad_potential[_qp].norm();
+    Real  d_vd_mag_d_potential = _mu[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
     Real d_delta_d_potential = _current_elem->hmax()/2.0*d_vd_mag_d_potential;
 
     return -_grad_test[_i][_qp] * -d_delta_d_potential * std::exp(_u[_qp]) * _grad_u[_qp] * _scale;

--- a/src/kernels/ElectronBolosKernel.C
+++ b/src/kernels/ElectronBolosKernel.C
@@ -48,20 +48,20 @@ ElectronBolosKernel::~ElectronBolosKernel()
 Real
 ElectronBolosKernel::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
 
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]-_diffem[_qp]*_grad_u[_qp]) // Transport
-    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm(); // Reaction. Townsend coefficient formulation
 	 // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 Real
 ElectronBolosKernel::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -69,7 +69,7 @@ ElectronBolosKernel::computeQpJacobian()
   _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp]);
   
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]*_phi[_j][_qp] - _diffem[_qp]*(_phi[_j][_qp]*_grad_u[_qp]+_grad_phi[_j][_qp])) // Transport
-    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.size()+1e-15); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+1e-15); // Reaction. Townsend coefficient formulation
 	 // -_grad_test[_i][_qp]*(-_delta*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp])); // Diffusion stabilization
 }
 
@@ -78,11 +78,11 @@ ElectronBolosKernel::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) { 
     _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp];
-    _em_flux_mag = _em_flux.size();
+    _em_flux_mag = _em_flux.norm();
     _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]);
     _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
-    _d_iz_d_potential = std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].size()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
+    _d_iz_d_potential = std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].norm()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
 
     return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_phi[_j][_qp])
       -_test[_i][_qp]*(_iz*_d_em_flux_mag_d_potential + _d_iz_d_potential*_em_flux_mag); // Reaction. Townsend coefficient formulation

--- a/src/kernels/ElectronBolosKernelEnergyForm.C
+++ b/src/kernels/ElectronBolosKernelEnergyForm.C
@@ -40,7 +40,7 @@ ElectronBolosKernelEnergyForm::~ElectronBolosKernelEnergyForm()
 Real
 ElectronBolosKernelEnergyForm::computeQpResidual()
 {
-  Real _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size();
+  Real _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm();
   Real _iz_term = _alpha_iz[_qp] * _electron_flux_mag;
 
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]-_diffem[_qp]*_grad_u[_qp])
@@ -60,7 +60,7 @@ ElectronBolosKernelEnergyForm::computeQpJacobian()
 
   RealVectorValue _electron_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp];
   RealVectorValue _d_electron_flux_d_em = -_d_muem_d_em*-_grad_potential[_qp]*std::exp(_u[_qp])-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]-_d_diffem_d_em*std::exp(_u[_qp])*_grad_u[_qp]-_diffem[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp]-_diffem[_qp]*std::exp(_u[_qp])*_grad_phi[_j][_qp];
-  Real _electron_flux_mag = _electron_flux.size();
+  Real _electron_flux_mag = _electron_flux.norm();
   Real _d_electron_flux_mag_d_em = _electron_flux*_d_electron_flux_d_em/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
 
   Real _d_iz_term_d_em = (_electron_flux_mag * _d_iz_d_em + _alpha_iz[_qp] * _d_electron_flux_mag_d_em);
@@ -83,7 +83,7 @@ ElectronBolosKernelEnergyForm::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue _electron_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp];
   RealVectorValue _d_electron_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]);
   RealVectorValue _d_electron_flux_d_mean_en = -_d_muem_d_mean_en*-_grad_potential[_qp]*std::exp(_u[_qp])-_d_diffem_d_mean_en*std::exp(_u[_qp])*_grad_u[_qp];
-  Real _electron_flux_mag = _electron_flux.size();
+  Real _electron_flux_mag = _electron_flux.norm();
   Real _d_electron_flux_mag_d_potential = _electron_flux*_d_electron_flux_d_potential/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real _d_electron_flux_mag_d_mean_en = _electron_flux*_d_electron_flux_d_mean_en/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronEnergyBolosKernel.C
+++ b/src/kernels/ElectronEnergyBolosKernel.C
@@ -57,7 +57,7 @@ ElectronEnergyBolosKernel::~ElectronEnergyBolosKernel()
 Real
 ElectronEnergyBolosKernel::computeQpResidual()
 {
-  Real _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  Real _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   Real _iz_term = _alpha_iz[_qp] * _electron_flux_mag * -_Eiz[_qp];
   Real _ex_term = _alpha_ex[_qp] * _electron_flux_mag * -_Eex[_qp];
   Real _Eel = 3.0*_mem[_qp]/_mip[_qp]*2.0/3*std::exp(_u[_qp]-_em[_qp]);
@@ -89,7 +89,7 @@ ElectronEnergyBolosKernel::computeQpJacobian()
 
   RealVectorValue _electron_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
   RealVectorValue _d_electron_flux_d_mean_en = -_d_muem_d_mean_en*-_grad_potential[_qp]*std::exp(_em[_qp])-_d_diffem_d_mean_en*std::exp(_em[_qp])*_grad_em[_qp];
-  Real _electron_flux_mag = _electron_flux.size();
+  Real _electron_flux_mag = _electron_flux.norm();
   Real _d_electron_flux_mag_d_mean_en = _electron_flux*_d_electron_flux_d_mean_en/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
 
   Real _d_Joule_d_mean_en = -_grad_potential[_qp] * _d_electron_flux_d_mean_en;
@@ -134,7 +134,7 @@ ElectronEnergyBolosKernel::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue _electron_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
   RealVectorValue _d_electron_flux_d_em = -_d_muem_d_em*-_grad_potential[_qp]*std::exp(_em[_qp])-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_d_diffem_d_em*std::exp(_em[_qp])*_grad_em[_qp]-_diffem[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]-_diffem[_qp]*std::exp(_em[_qp])*_grad_phi[_j][_qp];
   RealVectorValue _d_electron_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
-  Real _electron_flux_mag = _electron_flux.size();
+  Real _electron_flux_mag = _electron_flux.norm();
   Real _d_electron_flux_mag_d_em = _electron_flux*_d_electron_flux_d_em/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real _d_electron_flux_mag_d_potential = _electron_flux*_d_electron_flux_d_potential/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronEnergyKernel.C
+++ b/src/kernels/ElectronEnergyKernel.C
@@ -48,7 +48,7 @@ ElectronEnergyKernel::~ElectronEnergyKernel()
 Real
 ElectronEnergyKernel::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muel[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muel[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffel[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -66,7 +66,7 @@ ElectronEnergyKernel::computeQpResidual()
 Real
 ElectronEnergyKernel::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muel[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muel[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffel[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/ElectronEnergyLossFromElastic.C
+++ b/src/kernels/ElectronEnergyLossFromElastic.C
@@ -43,7 +43,7 @@ ElectronEnergyLossFromElastic::~ElectronEnergyLossFromElastic()
 Real
 ElectronEnergyLossFromElastic::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).size();
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).norm();
   Real Eel = -3.0 * _mem[_qp]/_mGas[_qp] * 2.0/3 * std::exp(_u[_qp]-_em[_qp]);
   Real el_term = _alpha_el[_qp] * electron_flux_mag * Eel;
 
@@ -61,7 +61,7 @@ ElectronEnergyLossFromElastic::computeQpJacobian()
 
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_mean_en = -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 
   Real Eel = -3.0 * _mem[_qp]/_mGas[_qp] * 2.0/3 * std::exp(_u[_qp]-_em[_qp]);
@@ -83,7 +83,7 @@ ElectronEnergyLossFromElastic::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_potential = -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_em = -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp]-d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential = electron_flux * d_electron_flux_d_potential/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronEnergyLossFromExcitation.C
+++ b/src/kernels/ElectronEnergyLossFromExcitation.C
@@ -40,7 +40,7 @@ ElectronEnergyLossFromExcitation::~ElectronEnergyLossFromExcitation()
 Real
 ElectronEnergyLossFromExcitation::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).size();
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).norm();
   Real ex_term = _alpha_ex[_qp] * electron_flux_mag;
 
   return -_test[_i][_qp] * ex_term * -_Eex[_qp];
@@ -57,7 +57,7 @@ ElectronEnergyLossFromExcitation::computeQpJacobian()
 
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_mean_en = -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_ex_term_d_mean_en = (electron_flux_mag * d_ex_d_mean_en + _alpha_ex[_qp] * d_electron_flux_mag_d_mean_en);
 
@@ -76,7 +76,7 @@ ElectronEnergyLossFromExcitation::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_potential = -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_em = -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp]-d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential = electron_flux * d_electron_flux_d_potential/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronEnergyLossFromIonization.C
+++ b/src/kernels/ElectronEnergyLossFromIonization.C
@@ -40,7 +40,7 @@ ElectronEnergyLossFromIonization::~ElectronEnergyLossFromIonization()
 Real
 ElectronEnergyLossFromIonization::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).size();
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).norm();
   Real iz_term = _alpha_iz[_qp] * electron_flux_mag;
 
   return -_test[_i][_qp] * iz_term * -_Eiz[_qp];
@@ -57,7 +57,7 @@ ElectronEnergyLossFromIonization::computeQpJacobian()
 
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_mean_en = -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_iz_term_d_mean_en = (electron_flux_mag * d_iz_d_mean_en + _alpha_iz[_qp] * d_electron_flux_mag_d_mean_en);
 
@@ -76,7 +76,7 @@ ElectronEnergyLossFromIonization::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_potential = -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_em = -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp]-d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential = electron_flux * d_electron_flux_d_potential/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronKernel.C
+++ b/src/kernels/ElectronKernel.C
@@ -44,20 +44,20 @@ ElectronKernel::~ElectronKernel()
 Real
 ElectronKernel::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
 
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]-_diffem[_qp]*_grad_u[_qp]) // Transport
-    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].size()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].norm()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm(); // Reaction. Townsend coefficient formulation
 	 // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 Real
 ElectronKernel::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -65,7 +65,7 @@ ElectronKernel::computeQpJacobian()
   _d_flux_d_u = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp]);
   
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]*_phi[_j][_qp] - _diffem[_qp]*(_phi[_j][_qp]*_grad_u[_qp]+_grad_phi[_j][_qp])) // Transport
-    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].size()))*_flux*_d_flux_d_u/(_flux.size()+1e-15); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].norm()))*_flux*_d_flux_d_u/(_flux.norm()+1e-15); // Reaction. Townsend coefficient formulation
 	 // -_grad_test[_i][_qp]*(-_delta*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp])); // Diffusion stabilization
 }
 
@@ -77,7 +77,7 @@ ElectronKernel::computeQpOffDiagJacobian(unsigned int jvar)
     _d_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]);
 
     return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_phi[_j][_qp])
-      -_test[_i][_qp]*_rate_coeff_ion[_qp]*(std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].size()))*_Eiz[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(1e-15+std::pow(_grad_potential[_qp].size(),3))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size() + std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].size()))*_flux*_d_flux_d_potential/(_flux.size()+1e-15)); // Reaction. Townsend coefficient formulation
+      -_test[_i][_qp]*_rate_coeff_ion[_qp]*(std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].norm()))*_Eiz[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(1e-15+std::pow(_grad_potential[_qp].norm(),3))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm() + std::exp(-_Eiz[_qp]/(1e-15+_grad_potential[_qp].norm()))*_flux*_d_flux_d_potential/(_flux.norm()+1e-15)); // Reaction. Townsend coefficient formulation
   }
 
   else {

--- a/src/kernels/ElectronKernelEnergyForm.C
+++ b/src/kernels/ElectronKernelEnergyForm.C
@@ -42,7 +42,7 @@ ElectronKernelEnergyForm::~ElectronKernelEnergyForm()
 Real
 ElectronKernelEnergyForm::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -56,7 +56,7 @@ ElectronKernelEnergyForm::computeQpResidual()
 Real
 ElectronKernelEnergyForm::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/ElectronKernelIntTD.C
+++ b/src/kernels/ElectronKernelIntTD.C
@@ -42,21 +42,21 @@ ElectronKernelIntTD::~ElectronKernelIntTD()
 Real
 ElectronKernelIntTD::computeQpResidual()
 {
-  _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+  _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
   _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
   _alpha = std::min(1.0,_Pe/6.0);
   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
   
   // Trying a logarithmic formulation
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(-_muem[_qp]*-_grad_potential[_qp]-_diffem[_qp]*_grad_u[_qp]) // Transport
-    -_test[_i][_qp]*_rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm(); // Reaction. Townsend coefficient formulation
 	 // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 // Real
 // ElectronKernelIntTD::computeQpJacobian()
 // {
-//   _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].size());
+//   _vd_mag = std::abs(_muem[_qp]*_grad_potential[_qp].norm());
 //   _Pe = _vd_mag*_current_elem->hmax()/_diffem[_qp];
 //   _alpha = std::min(1.0,_Pe/6.0);
 //   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/ElectronsFromIonization.C
+++ b/src/kernels/ElectronsFromIonization.C
@@ -39,7 +39,7 @@ ElectronsFromIonization::~ElectronsFromIonization()
 Real
 ElectronsFromIonization::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-_diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units).size();
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-_diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units).norm();
   Real iz_term = _alpha_iz[_qp] * electron_flux_mag;
 
   return -_test[_i][_qp] * iz_term;
@@ -58,7 +58,7 @@ ElectronsFromIonization::computeQpJacobian()
 
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-_diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_em = -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp]) * _phi[_j][_qp]-d_diffem_d_em * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units -_diffem[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp] * _r_units -_diffem[_qp] * std::exp(_u[_qp]) * _grad_phi[_j][_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 
   Real d_iz_term_d_em = (electron_flux_mag * d_iz_d_em + _alpha_iz[_qp] * d_electron_flux_mag_d_em);
@@ -79,7 +79,7 @@ ElectronsFromIonization::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue electron_flux = -_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-_diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_potential = -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_u[_qp]);
   RealVectorValue d_electron_flux_d_mean_en = -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_u[_qp])-d_diffem_d_mean_en * std::exp(_u[_qp]) * _grad_u[_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential = electron_flux * d_electron_flux_d_potential/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en/(electron_flux_mag+std::numeric_limits<double>::epsilon());
 

--- a/src/kernels/ElectronsFromIonizationLFA.C
+++ b/src/kernels/ElectronsFromIonizationLFA.C
@@ -45,7 +45,7 @@ ElectronsFromIonizationLFA::~ElectronsFromIonizationLFA()
 Real
 ElectronsFromIonizationLFA::computeQpResidual()
 {
-    return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).size();
+    return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp]).norm();
 }
 
 Real
@@ -54,7 +54,7 @@ ElectronsFromIonizationLFA::computeQpJacobian()
   RealVectorValue _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp];
   RealVectorValue _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp]);
 
-  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon());
+  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon());
 }
 
 Real
@@ -62,11 +62,11 @@ ElectronsFromIonizationLFA::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) { 
    RealVectorValue _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])-_diffem[_qp]*std::exp(_u[_qp])*_grad_u[_qp];
-   Real _em_flux_mag = _em_flux.size();
+   Real _em_flux_mag = _em_flux.norm();
    RealVectorValue _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]);
    Real _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-   Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
-   Real _d_iz_d_potential = std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].size()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+   Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
+   Real _d_iz_d_potential = std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].norm()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
 
     return -_test[_i][_qp]*(_iz*_d_em_flux_mag_d_potential + _d_iz_d_potential*_em_flux_mag);
   }

--- a/src/kernels/ElectronsFromIonizationLFA_KV.C
+++ b/src/kernels/ElectronsFromIonizationLFA_KV.C
@@ -45,7 +45,7 @@ ElectronsFromIonizationLFA_KV::~ElectronsFromIonizationLFA_KV()
 Real
 ElectronsFromIonizationLFA_KV::computeQpResidual()
 {
-    return -_test[_i][_qp] * _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp]) * std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon())) * (-_muem[_qp] * -_grad_potential[_qp] * std::exp(_u[_qp]) - _diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp]).size();
+    return -_test[_i][_qp] * _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp]) * std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon())) * (-_muem[_qp] * -_grad_potential[_qp] * std::exp(_u[_qp]) - _diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp]).norm();
 }
 
 Real
@@ -54,7 +54,7 @@ ElectronsFromIonizationLFA_KV::computeQpJacobian()
   RealVectorValue _em_flux = -_muem[_qp] * -_grad_potential[_qp] * std::exp(_u[_qp]) - _diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp];
   RealVectorValue _d_em_flux_d_em = -_muem[_qp] * -_grad_potential[_qp] * std::exp(_u[_qp]) * _phi[_j][_qp] - _diffem[_qp] * (std::exp(_u[_qp]) * _grad_phi[_j][_qp] + std::exp(_u[_qp]) * _phi[_j][_qp] * _grad_u[_qp]);
 
-  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon());
+  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()))*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon());
 }
 
 Real
@@ -62,14 +62,14 @@ ElectronsFromIonizationLFA_KV::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) {
    RealVectorValue _em_flux = -_muem[_qp] * -_grad_potential[_qp] * std::exp(_u[_qp])-_diffem[_qp] * std::exp(_u[_qp]) * _grad_u[_qp];
-   Real _em_flux_mag = _em_flux.size();
+   Real _em_flux_mag = _em_flux.norm();
    RealVectorValue _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]);
    Real _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-   Real _iz = _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()));
-   Real iz_first_product = std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]);
-   Real d_iz_first_product_d_potential = _iz_coeff_efield_b[_qp] * std::pow(1000. * _grad_potential[_qp].size() + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp] - 1.) * 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (_grad_potential[_qp].size() + std::numeric_limits<double>::epsilon());
-   Real iz_second_product = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()));
-   Real d_iz_second_product_d_potential = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon())) * _iz_coeff_efield_c[_qp] / 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (std::pow(_grad_potential[_qp].size(), 3.) + std::numeric_limits<double>::epsilon());
+   Real _iz = _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()));
+   Real iz_first_product = std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]);
+   Real d_iz_first_product_d_potential = _iz_coeff_efield_b[_qp] * std::pow(1000. * _grad_potential[_qp].norm() + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp] - 1.) * 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (_grad_potential[_qp].norm() + std::numeric_limits<double>::epsilon());
+   Real iz_second_product = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()));
+   Real d_iz_second_product_d_potential = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon())) * _iz_coeff_efield_c[_qp] / 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (std::pow(_grad_potential[_qp].norm(), 3.) + std::numeric_limits<double>::epsilon());
    Real d_iz_d_potential = _iz_coeff_efield_a[_qp] * (iz_first_product * d_iz_second_product_d_potential + d_iz_first_product_d_potential * iz_second_product);
 
     return -_test[_i][_qp] * (_iz * _d_em_flux_mag_d_potential + d_iz_d_potential * _em_flux_mag);

--- a/src/kernels/IonBolosKernel.C
+++ b/src/kernels/IonBolosKernel.C
@@ -51,20 +51,20 @@ IonBolosKernel::~IonBolosKernel()
 Real
 IonBolosKernel::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
  
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(_muip[_qp]*-_grad_potential[_qp]-_diffip[_qp]*_grad_u[_qp])
-    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm(); // Reaction. Townsend coefficient formulation
     // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 Real
 IonBolosKernel::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -78,11 +78,11 @@ IonBolosKernel::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) {
     _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
-    _em_flux_mag = _em_flux.size();
+    _em_flux_mag = _em_flux.norm();
     _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
     _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
-    _d_iz_d_potential = std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].size()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
+    _d_iz_d_potential = std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].norm()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
 
     return -_grad_test[_i][_qp]*(_muip[_qp]*-_grad_phi[_j][_qp]*std::exp(_u[_qp]))
       -_test[_i][_qp]*(_iz*_d_em_flux_mag_d_potential + _d_iz_d_potential*_em_flux_mag); // Reaction. Townsend coefficient formulation
@@ -91,9 +91,9 @@ IonBolosKernel::computeQpOffDiagJacobian(unsigned int jvar)
   else if (jvar == _em_id) {
     _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
     _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_em[_qp])*_grad_phi[_j][_qp]+std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]);
-    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
+    _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
 
-    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon()); // Reaction. Townsend coefficient formulation
+    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon()); // Reaction. Townsend coefficient formulation
 
   }
 

--- a/src/kernels/IonBolosKernelEnergyForm.C
+++ b/src/kernels/IonBolosKernelEnergyForm.C
@@ -78,10 +78,10 @@ IonBolosKernelEnergyForm::~IonBolosKernelEnergyForm()
 Real
 IonBolosKernelEnergyForm::computeQpResidual()
 {
-  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].size();
+  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].norm();
   Real  delta = vd_mag*_current_elem->hmax()/2.0;
 
-  Real  _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  Real  _electron_flux_mag = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   Real _iz_term = _alpha_iz[_qp] * _electron_flux_mag;
 
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(_muip[_qp]*-_grad_potential[_qp]-_diffip[_qp]*_grad_u[_qp])
@@ -93,7 +93,7 @@ IonBolosKernelEnergyForm::computeQpResidual()
 Real
 IonBolosKernelEnergyForm::computeQpJacobian()
 {
-  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].size();
+  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].norm();
   Real  delta = vd_mag*_current_elem->hmax()/2.0;
 
   return -_grad_test[_i][_qp]*(_muip[_qp]*-_grad_potential[_qp]*std::exp(_u[_qp])*_phi[_j][_qp]-_diffip[_qp]*(std::exp(_u[_qp])*_grad_phi[_j][_qp]+std::exp(_u[_qp])*_phi[_j][_qp]*_grad_u[_qp]))
@@ -118,7 +118,7 @@ IonBolosKernelEnergyForm::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue _d_electron_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
   RealVectorValue _d_electron_flux_d_mean_en = -_d_muem_d_mean_en*-_grad_potential[_qp]*std::exp(_em[_qp])-_d_diffem_d_mean_en*std::exp(_em[_qp])*_grad_em[_qp];
   RealVectorValue _d_electron_flux_d_em = -_d_muem_d_em*-_grad_potential[_qp]*std::exp(_em[_qp])-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_d_diffem_d_em*std::exp(_em[_qp])*_grad_em[_qp]-_diffem[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]-_diffem[_qp]*std::exp(_em[_qp])*_grad_phi[_j][_qp];
-  Real _electron_flux_mag = _electron_flux.size();
+  Real _electron_flux_mag = _electron_flux.norm();
   Real _d_electron_flux_mag_d_potential = _electron_flux*_d_electron_flux_d_potential/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real _d_electron_flux_mag_d_mean_en = _electron_flux*_d_electron_flux_d_mean_en/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real _d_electron_flux_mag_d_em = _electron_flux*_d_electron_flux_d_em/(_electron_flux_mag+std::numeric_limits<double>::epsilon());
@@ -127,8 +127,8 @@ IonBolosKernelEnergyForm::computeQpOffDiagJacobian(unsigned int jvar)
   Real _d_iz_term_d_mean_en = (_electron_flux_mag * _d_iz_d_mean_en + _alpha_iz[_qp] * _d_electron_flux_mag_d_mean_en);
   Real _d_iz_term_d_em = (_electron_flux_mag * _d_iz_d_em + _alpha_iz[_qp] * _d_electron_flux_mag_d_em);
 
-  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].size();
-  Real  d_vd_mag_d_potential = _muip[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+  Real  vd_mag = _muip[_qp]*_grad_potential[_qp].norm();
+  Real  d_vd_mag_d_potential = _muip[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
   Real d_delta_d_potential = _current_elem->hmax()/2.0*d_vd_mag_d_potential;
 
   if (jvar == _potential_id)

--- a/src/kernels/IonKernelEnergyForm.C
+++ b/src/kernels/IonKernelEnergyForm.C
@@ -47,7 +47,7 @@ IonKernelEnergyForm::~IonKernelEnergyForm()
 Real
 IonKernelEnergyForm::computeQpResidual()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
@@ -61,7 +61,7 @@ IonKernelEnergyForm::computeQpResidual()
 Real
 IonKernelEnergyForm::computeQpJacobian()
 {
-  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  // _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   // _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   // _alpha = std::min(1.0,_Pe/6.0);
   // _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/IonKernelIntTD.C
+++ b/src/kernels/IonKernelIntTD.C
@@ -45,20 +45,20 @@ IonKernelIntTD::~IonKernelIntTD()
 Real
 IonKernelIntTD::computeQpResidual()
 {
-  _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+  _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
   _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
   _alpha = std::min(1.0,_Pe/6.0);
   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;
  
   return -_grad_test[_i][_qp]*std::exp(_u[_qp])*(_muip[_qp]*-_grad_potential[_qp]-_diffip[_qp]*_grad_u[_qp])
-    -_test[_i][_qp]*_rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size(); // Reaction. Townsend coefficient formulation
+    -_test[_i][_qp]*_rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm(); // Reaction. Townsend coefficient formulation
     // -_grad_test[_i][_qp]*(-_delta*std::exp(_u[_qp])*_grad_u[_qp]); // Diffusion stabilization
 }
 
 // Real
 // IonKernelIntTD::computeQpJacobian()
 // {
-//   _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].size());
+//   _vd_mag = std::abs(_muip[_qp]*_grad_potential[_qp].norm());
 //   _Pe = _vd_mag*_current_elem->hmax()/_diffip[_qp];
 //   _alpha = std::min(1.0,_Pe/6.0);
 //   _delta = _alpha*_vd_mag*_current_elem->hmax()/2.0;

--- a/src/kernels/IonizationSource.C
+++ b/src/kernels/IonizationSource.C
@@ -47,15 +47,15 @@ This scaling is evident anywhere where you see the potential multiplied by _pote
 Real
 IonizationSource::computeQpResidual()
 {
-  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].size()*_u[_qp]; */
-  return -_test[_i][_qp]*std::max(std::exp(-1.0/(_grad_potential[_qp].size()+1.0e-6))*_velocity[_qp].size()*_u[_qp],0.0);
+  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].norm()*_u[_qp]; */
+  return -_test[_i][_qp]*std::max(std::exp(-1.0/(_grad_potential[_qp].norm()+1.0e-6))*_velocity[_qp].norm()*_u[_qp],0.0);
 }
 
 Real
 IonizationSource::computeQpJacobian()
 {
-  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].size()*_phi[_j][_qp]; */
-  return -_test[_i][_qp]*std::exp(-1.0/(_grad_potential[_qp].size()+1.0e-6))*_velocity[_qp].size()*_phi[_j][_qp];
+  /* return -_test[_i][_qp]*_ionization_coeff[_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*_velocity_coeff[_qp]*_potential_mult[_qp]*_grad_potential[_qp].norm()*_phi[_j][_qp]; */
+  return -_test[_i][_qp]*std::exp(-1.0/(_grad_potential[_qp].norm()+1.0e-6))*_velocity[_qp].norm()*_phi[_j][_qp];
 }
 
 /* Real
@@ -63,7 +63,7 @@ IonizationSource::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id)
   {
-    return _test[_i][_qp]*_ionization_coeff[_qp]*_velocity_coeff[_qp]*_u[_qp]*_potential_mult[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0))*(_ion_activation_energy[_qp]/(_grad_potential[_qp]*_grad_potential[_qp]*std::pow(_potential_mult[_qp],2)+1.0)-1.0/(_potential_mult[_qp]*_grad_potential[_qp].size()+1.0));
+    return _test[_i][_qp]*_ionization_coeff[_qp]*_velocity_coeff[_qp]*_u[_qp]*_potential_mult[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]*std::exp(-_ion_activation_energy[_qp]/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0))*(_ion_activation_energy[_qp]/(_grad_potential[_qp]*_grad_potential[_qp]*std::pow(_potential_mult[_qp],2)+1.0)-1.0/(_potential_mult[_qp]*_grad_potential[_qp].norm()+1.0));
   }
   
   return 0.0;

--- a/src/kernels/IonsFromIonization.C
+++ b/src/kernels/IonsFromIonization.C
@@ -42,7 +42,7 @@ IonsFromIonization::~IonsFromIonization()
 Real
 IonsFromIonization::computeQpResidual()
 {
-  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).size();
+  Real electron_flux_mag = (-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units).norm();
   Real iz_term = _alpha_iz[_qp] * electron_flux_mag;
 
   return -_test[_i][_qp] * iz_term;
@@ -72,7 +72,7 @@ IonsFromIonization::computeQpOffDiagJacobian(unsigned int jvar)
   RealVectorValue d_electron_flux_d_potential = -_muem[_qp] * -_grad_phi[_j][_qp] * _r_units * std::exp(_em[_qp]);
   RealVectorValue d_electron_flux_d_mean_en = -d_muem_d_mean_en * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-d_diffem_d_mean_en * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units;
   RealVectorValue d_electron_flux_d_em = -d_muem_d_em * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp])-_muem[_qp] * -_grad_potential[_qp] * _r_units * std::exp(_em[_qp]) * _phi[_j][_qp]-d_diffem_d_em * std::exp(_em[_qp]) * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _phi[_j][_qp] * _grad_em[_qp] * _r_units -_diffem[_qp] * std::exp(_em[_qp]) * _grad_phi[_j][_qp] * _r_units;
-  Real electron_flux_mag = electron_flux.size();
+  Real electron_flux_mag = electron_flux.norm();
   Real d_electron_flux_mag_d_potential = electron_flux * d_electron_flux_d_potential/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_mean_en = electron_flux * d_electron_flux_d_mean_en/(electron_flux_mag+std::numeric_limits<double>::epsilon());
   Real d_electron_flux_mag_d_em = electron_flux * d_electron_flux_d_em/(electron_flux_mag+std::numeric_limits<double>::epsilon());

--- a/src/kernels/IonsFromIonizationLFA.C
+++ b/src/kernels/IonsFromIonizationLFA.C
@@ -49,7 +49,7 @@ IonsFromIonizationLFA::~IonsFromIonizationLFA()
 Real
 IonsFromIonizationLFA::computeQpResidual()
 {
-  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
 }
 
 Real
@@ -63,11 +63,11 @@ IonsFromIonizationLFA::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) {
    RealVectorValue _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
-   Real _em_flux_mag = _em_flux.size();
+   Real _em_flux_mag = _em_flux.norm();
    RealVectorValue _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
    Real _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-   Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
-   Real _d_iz_d_potential = std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].size()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon());
+   Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
+   Real _d_iz_d_potential = std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]-2.0)*_iz_coeff_efield_a[_qp]*(_grad_potential[_qp].norm()*_iz_coeff_efield_b[_qp]+_iz_coeff_efield_c[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()))*_grad_potential[_qp]*_grad_phi[_j][_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon());
 
     return -_test[_i][_qp]*(_iz*_d_em_flux_mag_d_potential + _d_iz_d_potential*_em_flux_mag);
   }
@@ -75,9 +75,9 @@ IonsFromIonizationLFA::computeQpOffDiagJacobian(unsigned int jvar)
   else if (jvar == _em_id) {
     RealVectorValue _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
     RealVectorValue _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_em[_qp])*_grad_phi[_j][_qp]+std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]);
-    Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size()+std::numeric_limits<double>::epsilon()));
+    Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm()+std::numeric_limits<double>::epsilon()));
 
-    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon());
+    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon());
 
   }
 

--- a/src/kernels/IonsFromIonizationLFA_KV.C
+++ b/src/kernels/IonsFromIonizationLFA_KV.C
@@ -49,7 +49,7 @@ IonsFromIonizationLFA_KV::~IonsFromIonizationLFA_KV()
 Real
 IonsFromIonizationLFA_KV::computeQpResidual()
 {
-  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  return -_test[_i][_qp]*_iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()))*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
 }
 
 Real
@@ -63,14 +63,14 @@ IonsFromIonizationLFA_KV::computeQpOffDiagJacobian(unsigned int jvar)
 {
   if (jvar == _potential_id) {
    RealVectorValue _em_flux = -_muem[_qp] * -_grad_potential[_qp] * std::exp(_em[_qp])-_diffem[_qp] * std::exp(_em[_qp]) * _grad_em[_qp];
-   Real _em_flux_mag = _em_flux.size();
+   Real _em_flux_mag = _em_flux.norm();
    RealVectorValue _d_em_flux_d_potential = -_muem[_qp]*-_grad_phi[_j][_qp]*std::exp(_em[_qp]);
    Real _d_em_flux_mag_d_potential = _em_flux*_d_em_flux_d_potential/(_em_flux_mag+std::numeric_limits<double>::epsilon());
-   Real _iz = _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()));
-   Real iz_first_product = std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]);
-   Real d_iz_first_product_d_potential = _iz_coeff_efield_b[_qp] * std::pow(1000. * _grad_potential[_qp].size() + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp] - 1.) * 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (_grad_potential[_qp].size() + std::numeric_limits<double>::epsilon());
-   Real iz_second_product = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()));
-   Real d_iz_second_product_d_potential = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon())) * _iz_coeff_efield_c[_qp] / 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (std::pow(_grad_potential[_qp].size(), 3.) + std::numeric_limits<double>::epsilon());
+   Real _iz = _iz_coeff_efield_a[_qp] * std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()));
+   Real iz_first_product = std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp]);
+   Real d_iz_first_product_d_potential = _iz_coeff_efield_b[_qp] * std::pow(1000. * _grad_potential[_qp].norm() + std::numeric_limits<double>::epsilon(), _iz_coeff_efield_b[_qp] - 1.) * 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (_grad_potential[_qp].norm() + std::numeric_limits<double>::epsilon());
+   Real iz_second_product = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()));
+   Real d_iz_second_product_d_potential = std::exp(-_iz_coeff_efield_c[_qp] / (_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon())) * _iz_coeff_efield_c[_qp] / 1000. * _grad_potential[_qp] * _grad_phi[_j][_qp] / (std::pow(_grad_potential[_qp].norm(), 3.) + std::numeric_limits<double>::epsilon());
    Real d_iz_d_potential = _iz_coeff_efield_a[_qp] * (iz_first_product * d_iz_second_product_d_potential + d_iz_first_product_d_potential * iz_second_product);
 
     return -_test[_i][_qp] * (_iz * _d_em_flux_mag_d_potential + d_iz_d_potential * _em_flux_mag);
@@ -79,9 +79,9 @@ IonsFromIonizationLFA_KV::computeQpOffDiagJacobian(unsigned int jvar)
   else if (jvar == _em_id) {
     RealVectorValue _em_flux = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp];
     RealVectorValue _d_em_flux_d_em = -_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])*_phi[_j][_qp]-_diffem[_qp]*(std::exp(_em[_qp])*_grad_phi[_j][_qp]+std::exp(_em[_qp])*_phi[_j][_qp]*_grad_em[_qp]);
-    Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].size() * 1000. + std::numeric_limits<double>::epsilon()));
+    Real _iz = _iz_coeff_efield_a[_qp]*std::pow(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon(),_iz_coeff_efield_b[_qp])*std::exp(-_iz_coeff_efield_c[_qp]/(_grad_potential[_qp].norm() * 1000. + std::numeric_limits<double>::epsilon()));
 
-    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.size()+std::numeric_limits<double>::epsilon());
+    return -_test[_i][_qp]*_iz*_em_flux*_d_em_flux_d_em/(_em_flux.norm()+std::numeric_limits<double>::epsilon());
 
   }
 

--- a/src/kernels/PotentialDrivenArtificialDiff.C
+++ b/src/kernels/PotentialDrivenArtificialDiff.C
@@ -47,19 +47,19 @@ Real
 PotentialDrivenArtificialDiff::computeQpResidual()
 {
   _advection_velocity = _mobility[_qp]*-_grad_potential[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity[_qp]);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity[_qp]);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_u[_qp];    
   }
   else 
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_u[_qp];
   }
 }
@@ -68,19 +68,19 @@ Real
 PotentialDrivenArtificialDiff::computeQpJacobian()
 {
   _advection_velocity = _mobility[_qp]*-_grad_potential[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity[_qp]);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity[_qp]);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
   else
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
 }
@@ -91,11 +91,11 @@ PotentialDrivenArtificialDiff::computeQpOffDiagJacobian(unsigned int jvar)
   if (jvar == _potential_id)
     {
       _advection_velocity = _mobility[_qp]*-_grad_potential[_qp];
-      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity[_qp]);
+      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity[_qp]);
       _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
       if (!_consistent)
 	{
-	  return _delta * _current_elem->hmax() * std::pow(_mobility[_qp],2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.size(),2),1e-16)*_mobility[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.size(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
+	  return _delta * _current_elem->hmax() * std::pow(_mobility[_qp],2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.norm(),2),1e-16)*_mobility[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.norm(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
 	}
       else
 	{

--- a/src/kernels/PotentialDrivenArtificialDiffElectrons.C
+++ b/src/kernels/PotentialDrivenArtificialDiffElectrons.C
@@ -51,19 +51,19 @@ PotentialDrivenArtificialDiffElectrons::computeQpResidual()
 {
   _advection_velocity = _mobility[_qp]*-1.0*-_grad_potential[_qp];
   _diffusivity = _mobility[_qp]*_Te[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_u[_qp];    
   }
   else 
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_u[_qp];
   }
 }
@@ -73,19 +73,19 @@ PotentialDrivenArtificialDiffElectrons::computeQpJacobian()
 {
   _advection_velocity = _mobility[_qp]*-1.0*-_grad_potential[_qp];
   _diffusivity = _mobility[_qp]*_Te[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
   else
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
 }
@@ -99,11 +99,11 @@ PotentialDrivenArtificialDiffElectrons::computeQpOffDiagJacobian(unsigned int jv
     {
       _advection_velocity = _mobility[_qp]*-1.0*-_grad_potential[_qp];
       _diffusivity = _mobility[_qp]*_Te[_qp];
-      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
       _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
       if (!_consistent)
 	{
-	  return _delta * _current_elem->hmax() * std::pow(_mobility[_qp],2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.size(),2),1e-16)*_mobility[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.size(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
+	  return _delta * _current_elem->hmax() * std::pow(_mobility[_qp],2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.norm(),2),1e-16)*_mobility[_qp]*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.norm(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
 	}
       else
 	{

--- a/src/kernels/PotentialDrivenArtificialDiffEnergy.C
+++ b/src/kernels/PotentialDrivenArtificialDiffEnergy.C
@@ -54,19 +54,19 @@ PotentialDrivenArtificialDiffEnergy::computeQpResidual()
   _mobility_el = 5.0/3.0*_mobility_em[_qp];
   _advection_velocity = _mobility_el*-1.0*-_grad_potential[_qp];
   _diffusivity = _mobility_el*_u[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*1.5*(_em[_qp]*_grad_u[_qp]+_u[_qp]*_grad_em[_qp]);    
   }
   else 
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*1.5*(_em[_qp]*_grad_u[_qp]+_u[_qp]*_grad_em[_qp]);    
   }
 }
@@ -77,19 +77,19 @@ PotentialDrivenArtificialDiffEnergy::computeQpJacobian()
 {
   _advection_velocity = _mobility_el*-1.0*-_grad_potential[_qp];
   _diffusivity = _mobility_el*_Te[_qp];
-  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+  _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
   _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() * _alpha / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
   else
   {
     // Isotropic diffusion formulation of tau
-    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.size(),1e-16);
+    _tau = _delta * _current_elem->hmax() / std::max(_advection_velocity.norm(),1e-16);
     return _tau*_advection_velocity*_grad_test[_i][_qp]*_advection_velocity*_grad_phi[_j][_qp];    
   }
 }
@@ -103,11 +103,11 @@ PotentialDrivenArtificialDiffEnergy::computeQpOffDiagJacobian(unsigned int jvar)
     {
       _advection_velocity = _mobility_el*-1.0*-_grad_potential[_qp];
       _diffusivity = _mobility_el*_Te[_qp];
-      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.size(),1e-16) / (2.0 * _diffusivity);
+      _peclet_num = _current_elem->hmax() * std::max(_advection_velocity.norm(),1e-16) / (2.0 * _diffusivity);
       _alpha = 1.0 / std::tanh(std::max(_peclet_num,1e-16)) - 1.0 / std::max(_peclet_num,1e-16);
       if (!_consistent)
 	{
-	  return _delta * _current_elem->hmax() * std::pow(_mobility_el,2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.size(),2),1e-16)*_mobility_el*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.size(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
+	  return _delta * _current_elem->hmax() * std::pow(_mobility_el,2)*_grad_u[_qp]*_grad_test[_i][_qp] * (1.0 / -std::max(std::pow(_advection_velocity.norm(),2),1e-16)*_mobility_el*_grad_potential[_qp]*_grad_phi[_j][_qp]/std::sqrt(std::max(_grad_potential[_qp]*_grad_potential[_qp],1e-16))*-_grad_potential[_qp]*-_grad_potential[_qp] + 1.0 / std::max(_advection_velocity.norm(),1e-16)*2.0*_grad_potential[_qp]*_grad_phi[_j][_qp]);
 	}
       else
 	{

--- a/src/kernels/TimeDerivativeSUPG.C
+++ b/src/kernels/TimeDerivativeSUPG.C
@@ -57,22 +57,22 @@ TimeDerivativeSUPG::computeQpResidual()
 {
   if (_crosswind)
     {
-      if (_grad_u[_qp].size() == 0.0)
+      if (_grad_u[_qp].norm() == 0.0)
 	{
 	  _velocity_h = _velocity[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma*_velocity_h * _grad_test[_i][_qp] ) * _u_dot[_qp];
 	}
       else
 	{
-	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].size() * _grad_u[_qp].size() + _epsilon ) * _grad_u[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].norm() * _grad_u[_qp].norm() + _epsilon ) * _grad_u[_qp];
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma*_velocity_h * _grad_test[_i][_qp] )  * _u_dot[_qp];
@@ -89,12 +89,12 @@ TimeDerivativeSUPG::computeQpJacobian()
 {
   if (_crosswind)
     {
-      if (_grad_u[_qp].size() == 0.0)
+      if (_grad_u[_qp].norm() == 0.0)
 	{
 	  _velocity_h = _velocity[_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 	  return (_tau[_qp]*_velocity[_qp]*_grad_test[_i][_qp] + _sigma*_velocity_h * _grad_test[_i][_qp] ) * _phi[_j][_qp] * _du_dot_du[_qp];
@@ -102,11 +102,11 @@ TimeDerivativeSUPG::computeQpJacobian()
       else
 	{
 
-	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].size() * _grad_u[_qp].size() + _epsilon ) * _grad_u[_qp];
-	  _d_velocity_h_d_uj =  (std::pow(_grad_u[_qp].size(),2)* ( _velocity[_qp] * _grad_phi[_j][_qp])-(_velocity[_qp] * _grad_u[_qp] )* ( 2.0 * _grad_u[_qp] * _grad_phi[_j][_qp] ) ) / std::pow(_grad_u[_qp].size(),4)*_grad_u[_qp] + _velocity[_qp]*_grad_u[_qp] / std::pow(_grad_u[_qp].size(),2) * _grad_phi[_j][_qp];
-	  _peclet_num_h = _current_elem->hmax() * _velocity_h.size() / (2.0 * _diffusivity[_qp]);
+	  _velocity_h = _velocity[_qp]*_grad_u[_qp] / ( _grad_u[_qp].norm() * _grad_u[_qp].norm() + _epsilon ) * _grad_u[_qp];
+	  _d_velocity_h_d_uj =  (std::pow(_grad_u[_qp].norm(),2)* ( _velocity[_qp] * _grad_phi[_j][_qp])-(_velocity[_qp] * _grad_u[_qp] )* ( 2.0 * _grad_u[_qp] * _grad_phi[_j][_qp] ) ) / std::pow(_grad_u[_qp].norm(),4)*_grad_u[_qp] + _velocity[_qp]*_grad_u[_qp] / std::pow(_grad_u[_qp].norm(),2) * _grad_phi[_j][_qp];
+	  _peclet_num_h = _current_elem->hmax() * _velocity_h.norm() / (2.0 * _diffusivity[_qp]);
 	  _alpha_h = 1.0 / std::tanh(_peclet_num_h) - 1.0 / _peclet_num_h;
-	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.size());
+	  _tau_h = _current_elem->hmax() * _alpha_h / (2.0*_velocity_h.norm());
 	  //	  _sigma = std::max(0.0,_tau_h-_tau[_qp]);
 	  _sigma = _tau_h;
 

--- a/src/materials/Air.C
+++ b/src/materials/Air.C
@@ -126,11 +126,11 @@ Air::computeQpProperties()
   _alpha_0[_qp] = 4332.0*100.0; // Ebert article
   _E_0[_qp] = 2.0e7; // Ebert article
   
-  _s[_qp] = std::max(_em[_qp],0.0)*std::abs(_muem[_qp])*_grad_potential[_qp].size()*_potential_mult[_qp]*_alpha_0[_qp]*std::exp(-_E_0[_qp]/(_grad_potential[_qp].size()*_potential_mult[_qp]+1.0));
+  _s[_qp] = std::max(_em[_qp],0.0)*std::abs(_muem[_qp])*_grad_potential[_qp].norm()*_potential_mult[_qp]*_alpha_0[_qp]*std::exp(-_E_0[_qp]/(_grad_potential[_qp].norm()*_potential_mult[_qp]+1.0));
   _sem[_qp] = _s[_qp];
   _sip[_qp] = _s[_qp];
   _spotential[_qp] = _N_A[_qp]*_e[_qp]/(_eps_r[_qp]*_eps_0[_qp]*_potential_mult[_qp])*(std::max(_em[_qp],0.0)*_zem[_qp]+std::max(_ip[_qp],0.0)*_zip[_qp]);
-  _Jac_em[_qp] = std::abs(_muem[_qp])*_grad_potential[_qp].size()*_potential_mult[_qp]*_alpha_0[_qp]*std::exp(-_E_0[_qp]/(_grad_potential[_qp].size()*_potential_mult[_qp]+1.0));
+  _Jac_em[_qp] = std::abs(_muem[_qp])*_grad_potential[_qp].norm()*_potential_mult[_qp]*_alpha_0[_qp]*std::exp(-_E_0[_qp]/(_grad_potential[_qp].norm()*_potential_mult[_qp]+1.0));
   _Jac_ip[_qp] = 0.0;
   _Jac_potential[_qp] = 0.0;
 
@@ -159,19 +159,19 @@ Air::computeQpProperties()
       _velocity[_qp](2) = 0.0;
       }
 
-    _velocity_norm_vector[_qp] = _velocity[_qp] / _velocity[_qp].size();  
-    _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].size() / (2.0 * _diffusivity[_qp]);
+    _velocity_norm_vector[_qp] = _velocity[_qp] / _velocity[_qp].norm();  
+    _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].norm() / (2.0 * _diffusivity[_qp]);
   _alpha[_qp] = 1.0 / std::tanh(_peclet_num[_qp]) - 1.0 / _peclet_num[_qp];
   
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].size();
+    _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].norm();
   }
   else if (!_consistent)
   {
     // Isotropic diffusion formulation of tau
 
-    _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].size();
+    _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].norm();
     }*/
 }

--- a/src/materials/AirConstTD.C
+++ b/src/materials/AirConstTD.C
@@ -102,7 +102,7 @@ AirConstTD::computeQpProperties()
   _N_A[_qp] = 6.02e23; 
 
   // _ElectronTotalFluxMag[_qp] = std::sqrt((-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp])*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]));
-  // _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  // _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   // _ElectronTotalFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
   // _ElectronAdvectiveFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp]);
   // _ElectronDiffusiveFlux[_qp] = -_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
@@ -110,6 +110,6 @@ AirConstTD::computeQpProperties()
   // _IonAdvectiveFlux[_qp] = -_muip[_qp]*-_grad_potential[_qp](0)*std::exp(_ip[_qp]);
   // _IonDiffusiveFlux[_qp] = -_diffip[_qp]*std::exp(_ip[_qp])*_grad_ip[_qp](0);
   _EField[_qp] = -_grad_potential[_qp](0);
-  // _Source_term[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].size())*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
-  // _Source_term_coeff[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].size());
+  // _Source_term[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].norm())*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
+  // _Source_term_coeff[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].norm());
 }

--- a/src/materials/Argon.C
+++ b/src/materials/Argon.C
@@ -105,11 +105,11 @@ Argon::Argon(const InputParameters & parameters) :
 void
 Argon::computeQpProperties()
 {  
-  _muem[_qp] = _mobility_interpolation.sample(_grad_potential[_qp].size());
-  _diffem[_qp] = _diffusivity_interpolation.sample(_grad_potential[_qp].size());
+  _muem[_qp] = _mobility_interpolation.sample(_grad_potential[_qp].norm());
+  _diffem[_qp] = _diffusivity_interpolation.sample(_grad_potential[_qp].norm());
   _muip[_qp] = _muem[_qp]/100.0;
   _diffip[_qp] = -_diffem[_qp]/100.0;
-  _rate_coeff_ion[_qp] = _alpha_interpolation.sample(_grad_potential[_qp].size()); // rate_coeff_ion is synonymous with alpha in this case. 
+  _rate_coeff_ion[_qp] = _alpha_interpolation.sample(_grad_potential[_qp].norm()); // rate_coeff_ion is synonymous with alpha in this case. 
   _Ar[_qp] = 1.01e5/(300*1.38e-23);
   _muel[_qp] = 5.0/3.0*_muem[_qp];
   _diffel[_qp] = 5.0/3.0*_diffem[_qp];
@@ -126,7 +126,7 @@ Argon::computeQpProperties()
   _vthermal_ip[_qp] = 1.6*sqrt(_k_boltz[_qp]*_Tip_lfa[_qp]/_mip[_qp]);
 
   _ElectronTotalFluxMag[_qp] = std::sqrt((-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp])*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]));
-  _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   _ElectronTotalFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
   _ElectronAdvectiveFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp]);
   _ElectronDiffusiveFlux[_qp] = -_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
@@ -134,6 +134,6 @@ Argon::computeQpProperties()
   _IonAdvectiveFlux[_qp] = -_muip[_qp]*-_grad_potential[_qp](0)*std::exp(_ip[_qp]);
   _IonDiffusiveFlux[_qp] = -_diffip[_qp]*std::exp(_ip[_qp])*_grad_ip[_qp](0);
   _EField[_qp] = -_grad_potential[_qp](0);
-  _Source_term[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].size())*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
-  _Source_term_coeff[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].size());
+  _Source_term[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].norm())*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
+  _Source_term_coeff[_qp] = _rate_coeff_ion[_qp]*std::exp(-_Eiz[_qp]/_grad_potential[_qp].norm());
 }

--- a/src/materials/InterpolateTD.C
+++ b/src/materials/InterpolateTD.C
@@ -101,11 +101,11 @@ InterpolateTD::InterpolateTD(const InputParameters & parameters) :
 void
 InterpolateTD::computeQpProperties()
 {  
-  _muem[_qp] = _mobility_interpolation.sample(_grad_potential[_qp].size());
-  _diffem[_qp] = _diffusivity_interpolation.sample(_grad_potential[_qp].size());
+  _muem[_qp] = _mobility_interpolation.sample(_grad_potential[_qp].norm());
+  _diffem[_qp] = _diffusivity_interpolation.sample(_grad_potential[_qp].norm());
   _muip[_qp] = _muem[_qp]/100.0;
   _diffip[_qp] = -_diffem[_qp]/100.0;
-  _rate_coeff_ion[_qp] = _alpha_interpolation.sample(_grad_potential[_qp].size()); // rate_coeff_ion is synonymous with alpha in this case. 
+  _rate_coeff_ion[_qp] = _alpha_interpolation.sample(_grad_potential[_qp].norm()); // rate_coeff_ion is synonymous with alpha in this case. 
   _Ar[_qp] = 1.01e5/(300*1.38e-23);
   _muel[_qp] = 5.0/3.0*_muem[_qp];
   _diffel[_qp] = 5.0/3.0*_diffem[_qp];
@@ -122,7 +122,7 @@ InterpolateTD::computeQpProperties()
   _vthermal_ip[_qp] = 1.6*sqrt(_k_boltz[_qp]*_Tip_lfa[_qp]/_mip[_qp]);
 
   _ElectronTotalFluxMag[_qp] = std::sqrt((-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp])*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]));
-  _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  _ElectronTotalFluxMagSizeForm[_qp] = (-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   _ElectronTotalFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
   _ElectronAdvectiveFlux[_qp] = -_muem[_qp]*-_grad_potential[_qp](0)*std::exp(_em[_qp]);
   _ElectronDiffusiveFlux[_qp] = -_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp](0);
@@ -130,6 +130,6 @@ InterpolateTD::computeQpProperties()
   _IonAdvectiveFlux[_qp] = -_muip[_qp]*-_grad_potential[_qp](0)*std::exp(_ip[_qp]);
   _IonDiffusiveFlux[_qp] = -_diffip[_qp]*std::exp(_ip[_qp])*_grad_ip[_qp](0);
   _EField[_qp] = -_grad_potential[_qp](0);
-  _Source_term[_qp] = _rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).size();
+  _Source_term[_qp] = _rate_coeff_ion[_qp]*(-_muem[_qp]*-_grad_potential[_qp]*std::exp(_em[_qp])-_diffem[_qp]*std::exp(_em[_qp])*_grad_em[_qp]).norm();
   _Source_term_coeff[_qp] = _rate_coeff_ion[_qp];
 }

--- a/src/materials/NoCouplingAir.C
+++ b/src/materials/NoCouplingAir.C
@@ -111,19 +111,19 @@ NoCouplingAir::computeQpProperties()
     {
       _velocity[_qp] = _velocity_function.vectorValue(_t,_qp);
     }
-  _velocity_norm[_qp] = _velocity[_qp] / _velocity[_qp].size();
-  _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].size() / (2.0 * _diffusivity[_qp]);
+  _velocity_norm[_qp] = _velocity[_qp] / _velocity[_qp].norm();
+  _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].norm() / (2.0 * _diffusivity[_qp]);
   _alpha[_qp] = 1.0 / std::tanh(_peclet_num[_qp]) - 1.0 / _peclet_num[_qp];
 
   if (_consistent)
   {
     // Consistent diffusion formulation of tau
-    _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].size();
+    _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].norm();
   }
   else if (!_consistent)
   {
     // Isotropic diffusion formulation of tau
 
-    _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].size();
+    _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].norm();
   }
 }

--- a/src/materials/WD.C
+++ b/src/materials/WD.C
@@ -99,19 +99,19 @@ WD::computeQpProperties()
     {
       _velocity[_qp] = _velocity_function.vectorValue(_t,_qp);
     }
-  _velocity_norm[_qp] = _velocity[_qp] / _velocity[_qp].size();
-  _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].size() / (2.0 * _diffusivity[_qp]);
+  _velocity_norm[_qp] = _velocity[_qp] / _velocity[_qp].norm();
+  _peclet_num[_qp] = _current_elem->hmax() * _velocity[_qp].norm() / (2.0 * _diffusivity[_qp]);
   _alpha[_qp] = 1.0 / std::tanh(_peclet_num[_qp]) - 1.0 / _peclet_num[_qp];
 
   if (_consistent)
     {
       // Consistent diffusion formulation of tau
-      _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].size();
+      _tau[_qp] = _delta * _current_elem->hmax() * _alpha[_qp] / _velocity[_qp].norm();
     }
   else if (!_consistent)
     {
       // Isotropic diffusion formulation of tau
 
-      _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].size();
+      _tau[_qp] = _delta * _current_elem->hmax() / _velocity[_qp].norm();
     }
 }


### PR DESCRIPTION
They are replaced by norm() and norm_sq(), respectively.

Refs libMesh/libmesh#829.

Sorry for the big change -- most apps do not use `TypeVector::size()` nearly as much as yours does...